### PR TITLE
Add default config dictionary

### DIFF
--- a/snitch/constants.py
+++ b/snitch/constants.py
@@ -1,0 +1,1 @@
+DEFAULT_CONFIG = {"kwargs": {"actor": "actor", "trigger": "trigger", "target": "target"}}

--- a/tests/app/helpers.py
+++ b/tests/app/helpers.py
@@ -1,11 +1,12 @@
 import snitch
 from snitch import explicit_dispatch
+from snitch.constants import DEFAULT_CONFIG
 from tests.app.events import DUMMY_EVENT
 
 
 @snitch.dispatch(
     DUMMY_EVENT,
-    config={"kwargs": {"actor": "actor", "trigger": "trigger", "target": "target"}},
+    config=DEFAULT_CONFIG,
 )
 def dispatch_dummy_event(actor, trigger, target):
     pass
@@ -14,7 +15,7 @@ def dispatch_dummy_event(actor, trigger, target):
 def dispatch_explicit_dummy_event(actor, trigger, target):
     explicit_dispatch(
         verb=DUMMY_EVENT,
-        config={"kwargs": {"actor": "actor", "trigger": "trigger", "target": "target"}},
+        config=DEFAULT_CONFIG,
         actor=actor,
         trigger=trigger,
         target=target,


### PR DESCRIPTION
Since `{"kwargs": {"actor": "actor", "trigger": "trigger", "target": "target"}}` is the most used type of config I think is appropriate to define a constant holding that config follow DRY.