### PR TITLE
Add emails to template if list or tuple

### DIFF
--- a/snitch/emails.py
+++ b/snitch/emails.py
@@ -37,6 +37,8 @@ class TemplateEmailMessage:
             warnings.warn("You have to specify the template name")
         if not isinstance(to, list) and not isinstance(to, tuple):
             self.to = [to]
+        else:
+            self.to = to
         self.subject = "%s" % self.default_subject if subject is None else subject
         self.from_email = self.default_from_email if from_email is None else from_email
         self.attaches = [] if attaches is None else attaches


### PR DESCRIPTION
When use TemplateEmailMessage for send a email to group I received the next error:
AttributeError: 'MyEmailExtendedFromTemplateEmailMessage' object has no attribute 'to'
This is because if the "to" attribute is a list or tuple that the constructor ignores.