### PR TITLE
fix: take into account cc, bcc and reply_to in async emails + fix typing

### DIFF
--- a/snitch/emails.py
+++ b/snitch/emails.py
@@ -20,9 +20,9 @@ class TemplateEmailMessage:
     default_template_name: str = ""
     default_subject: str = ""
     default_from_email: str = ""
-    default_reply_to: str = ""
-    default_bcc: str = ""
-    default_cc: str = ""
+    default_reply_to: List[str] = [""]
+    default_bcc: List[str] = [""]
+    default_cc: List[str] = [""]
     fake: bool = False
     use_i18n: bool = False
 
@@ -34,9 +34,9 @@ class TemplateEmailMessage:
         from_email: Optional[str] = None,
         attaches: Optional[List] = None,
         template_name: Optional[str] = None,
-        reply_to: Optional[str] = None,
-        bcc: Optional[str] = None,
-        cc: Optional[str] = None,
+        reply_to: Optional[List] = None,
+        bcc: Optional[List] = None,
+        cc: Optional[List] = None,
     ):
         self.template_name = (
             self.default_template_name if template_name is None else template_name
@@ -75,7 +75,14 @@ class TemplateEmailMessage:
     def async_send(self, message, message_txt):
         if not self.fake:
             send_email_asynchronously.delay(
-                self.subject, message_txt, message, self.from_email, self.to
+                self.subject,
+                message_txt,
+                message,
+                self.from_email,
+                self.to,
+                self.cc,
+                self.bcc,
+                self.reply_to,
             )
             if self.attaches:
                 warnings.warn(

--- a/snitch/tasks.py
+++ b/snitch/tasks.py
@@ -23,11 +23,24 @@ def send_notification_task(notification_pk: int) -> Optional[bool]:
 
 @task(serializer="json")
 def send_email_asynchronously(
-    subject: str, message_txt: str, message: str, from_email: str, to: Union[List, str]
+    subject: str,
+    message_txt: str,
+    message: str,
+    from_email: str,
+    to: Union[List, str],
+    cc: Optional[List],
+    bcc: Optional[List],
+    reply_to: Optional[List],
 ):
     """Sends an email as a asynchronous task."""
     email = EmailMultiAlternatives(
-        subject=subject, body=message_txt, from_email=from_email, to=to
+        subject=subject,
+        body=message_txt,
+        from_email=from_email,
+        to=to,
+        cc=cc,
+        bcc=bcc,
+        reply_to=reply_to,
     )
     email.attach_alternative(message, "text/html")
     email.send()

--- a/tests/test_snitch.py
+++ b/tests/test_snitch.py
@@ -1,4 +1,3 @@
-import locale
 import warnings
 
 from django.test import TestCase
@@ -173,6 +172,22 @@ class SnitchTestCase(TestCase):
         try:
             email = WelcomeEmail(to="test@example.com", context={})
             email.send(use_async=False)
+            exception = False
+        except Exception:
+            exception = True
+        self.assertFalse(exception)
+
+    def test_send_email_with_cc_and_bcc(self):
+        try:
+            email = WelcomeEmail(
+                to="test@example.com",
+                cc=["test@test.com"],
+                bcc=["test@tost.com"],
+                context={},
+            )
+            email.send(use_async=False)
+            self.assertEqual(email.cc, ["test@test.com"])
+            self.assertEqual(email.bcc, ["test@tost.com"])
             exception = False
         except Exception:
             exception = True


### PR DESCRIPTION
- fix: async emails not taking into account the fields cc, bcc and reply_to
- fix: cc, bcc and reply_to must be lists