### PR TITLE
fix: `TemplateEmailMessage` bcc and cc are initiated as empty lists

### DIFF
--- a/snitch/emails.py
+++ b/snitch/emails.py
@@ -53,8 +53,12 @@ class TemplateEmailMessage:
                 setattr(self, attr_name, attr)
         self.to = to if isinstance(to, (list, tuple)) else [to]
         self.reply_to = reply_to
-        self.bcc = bcc if isinstance(bcc, (list, tuple)) else [bcc]
-        self.cc = cc if isinstance(cc, (list, tuple)) else [cc]
+        self.bcc = (
+            bcc if isinstance(bcc, (list, tuple)) else [bcc] if bcc is not None else []
+        )
+        self.cc = (
+            cc if isinstance(cc, (list, tuple)) else [cc] if bcc is not None else []
+        )
         self.subject = self.default_subject if subject is None else subject
         self.from_email = self.default_from_email if from_email is None else from_email
         self.attaches = [] if attaches is None else attaches

--- a/tests/test_snitch.py
+++ b/tests/test_snitch.py
@@ -178,6 +178,13 @@ class SnitchTestCase(TestCase):
     def test_send_email(self):
         try:
             email = WelcomeEmail(to="test@example.com", context={})
+            self.assertEqual(email.template_name, email.default_template_name)
+            self.assertEqual(email.subject, email.default_subject)
+            self.assertEqual(email.from_email, email.default_from_email)
+            self.assertEqual(email.bcc, [])
+            self.assertEqual(email.cc, [])
+            self.assertEqual(email.attaches, [])
+            self.assertEqual(email.default_context, {})
             email.send(use_async=False)
             exception = False
         except Exception:


### PR DESCRIPTION
Regarding issue #21.